### PR TITLE
Fix loading indicator in ContactForm

### DIFF
--- a/src/components/ContactForm/ContactForm.jsx
+++ b/src/components/ContactForm/ContactForm.jsx
@@ -106,7 +106,8 @@ const ContactForm = () => {
               type="submit"
               variant="contained"
               color="primary"
-              disabled={isLoading && <CircularProgress size={20} />}
+              disabled={isLoading}
+              startIcon={isLoading && <CircularProgress size={20} />}
               sx={{
                 mr: 'auto',
                 ml: 'auto',
@@ -115,7 +116,7 @@ const ContactForm = () => {
                 minWidth: '76px',
               }}
             >
-              Add Contact
+              {isLoading ? null : 'Add Contact'}
             </Button>
           </Box>
         </Form>


### PR DESCRIPTION
## Summary
- use `disabled={isLoading}` for submit button
- show `CircularProgress` with `startIcon` when loading

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fa21b0c748333af6bbff381bf8569